### PR TITLE
fix: RangeError

### DIFF
--- a/lib/DI.js
+++ b/lib/DI.js
@@ -45,7 +45,7 @@
     };
 
     DI.prototype.addService = function(name, service, args) {
-      var arg, i, originalService, _i, _len;
+      var originalService;
       if (args == null) {
         args = [];
       }
@@ -63,10 +63,6 @@
           }
           this.paths[service] = name;
         }
-      }
-      for (i = _i = 0, _len = args.length; _i < _len; i = ++_i) {
-        arg = args[i];
-        args[i] = this.tryCallArgument(arg);
       }
       this.services[name] = new Service(this, name, service, args);
       this.services[name].setInstantiate(this.instantiate);

--- a/src/DI.coffee
+++ b/src/DI.coffee
@@ -57,9 +57,6 @@ class DI
 
 				@paths[service] = name
 
-		for arg, i in args
-			args[i] = @tryCallArgument(arg)
-
 		@services[name] = new Service(@, name, service, args)
 		@services[name].setInstantiate(@instantiate)
 		return @services[name]


### PR DESCRIPTION
for arg, i in args
   args[i] = @tryCallArgument(arg)

Code from above added in 2.3.2 version somtimes throws an error: Maximum call stack size exceeded.
It is thrown in Helpers.clone method (my best guess is circular reference).
